### PR TITLE
search: fix number of results

### DIFF
--- a/invenio/legacy/search_engine/__init__.py
+++ b/invenio/legacy/search_engine/__init__.py
@@ -5541,7 +5541,7 @@ def perform_request_search(req=None, cc=CFG_SITE_NAME, c=None, p="", f="", rg=No
                         d1y=0, d1m=0, d1d=0, d2="", d2y=0, d2m=0, d2d=0, dt="", verbose=0, ap=0, ln=CFG_SITE_LANG, ec=None, tab="",
                         wl=0, em=""):
     """Perform search or browse request, without checking for
-       authentication.  Return list of recIDs found, if of=id.
+       authentication.  Return list of recIDs found, if of=id or of=intbitset.
        Otherwise create web page.
 
        The arguments are as follows:
@@ -5561,7 +5561,7 @@ def perform_request_search(req=None, cc=CFG_SITE_NAME, c=None, p="", f="", rg=No
 
           rg - records in groups of (e.g. "10").  Defines how many hits
                per collection in the search results page are
-               displayed.  (Note that `rg' is ignored in case of `of=id'.)
+               displayed.  (Note that `rg' is ignored in case of `of=intbitset'.)
 
           sf - sort field (e.g. "title").
 
@@ -5636,7 +5636,7 @@ def perform_request_search(req=None, cc=CFG_SITE_NAME, c=None, p="", f="", rg=No
 
         jrec - jump to record (e.g. "234").  Used for navigation
                inside the search results.  (Note that `jrec' is ignored
-               in case of `of=id'.)
+               in case of `of=intbitset'.)
 
        recid - display record ID (e.g. "20000").  Do not
                search/browse but go straight away to the Detailed

--- a/invenio/modules/search/views/search.py
+++ b/invenio/modules/search/views/search.py
@@ -462,7 +462,7 @@ def search(collection, p, of, ot, so, rm):
 
     ctx = dict(
         facets=facets.get_facets_config(collection, qid),
-        records=len(get_current_user_records_that_can_be_displayed(qid)),
+        records=len(recids),
         qid=qid, rg=rg,
         create_nearest_terms_box=lambda: _create_neareset_term_box(argd_orig),
         easy_search_form=EasySearchForm(csrf_enabled=False),

--- a/invenio/modules/search/views/search.py
+++ b/invenio/modules/search/views/search.py
@@ -444,6 +444,10 @@ def search(collection, p, of, ot, so, rm):
     qid = get_search_query_id(**argd)
     recids = perform_request_search(req=request.get_legacy_request(), **argd)
 
+    # second search to get the total number of results
+    argd['of'] = 'intbitset'
+    total_number_of_results = len(perform_request_search(req=request.get_legacy_request(), **argd))
+
     # back-to-search related code
     if request and not isinstance(request.get_legacy_request(),
                                   cStringIO.OutputType):
@@ -462,7 +466,7 @@ def search(collection, p, of, ot, so, rm):
 
     ctx = dict(
         facets=facets.get_facets_config(collection, qid),
-        records=len(recids),
+        records=total_number_of_results,
         qid=qid, rg=rg,
         create_nearest_terms_box=lambda: _create_neareset_term_box(argd_orig),
         easy_search_form=EasySearchForm(csrf_enabled=False),


### PR DESCRIPTION
Under certain conditions, the number of results found is wrong.
- use `len(recids)` to get the exact number or results
# Detailed description

This bug occurs when you have specific settings for the collection tree. Below are the settings used to get the bug
## Collection settings

we have the main (root) collection named `MAIN` and 2 collections:
- `image` which is a direct child of `MAIN`
- `negative` which is NOT part of the collection tree, it is not a child of `MAIN`

The goal is here to have the images in `image` and their negatives in `negative`. What we want is when you search for an image, you only get results from the `image` collection, and not from `negative`. When you look at a record from `image`, you will have a link to its negatives in `negative`, so both collections need to be public.

This is a simple test case, the main point is that we have 2 public collections with only one in the tree.
## The bug
### What is happening

when we search for an image, we only get results from `image` BUT the number of total results is wrong. If we have 4 results in `image` and 4 results in `negative`
- we get only the 4 results from `image` (good)
- the total number of records is 8 (4 + 4), so we have something like _"1 to 8 results on 8"_ while we only see 4...
### what should happen

Obviously, we should get the right number of results, so _4_ in the previous example
## The fix

The fix is very simple: we only take the number found records as the total of results (see the commit).

It has been tested with restricted collections and the facets, everything seems to work.
